### PR TITLE
[Fix] 1번 스킬 로직 재설정

### DIFF
--- a/Assets/01.Scenes/GoHyeokBin/#46/#46.unity
+++ b/Assets/01.Scenes/GoHyeokBin/#46/#46.unity
@@ -853,12 +853,13 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   skillType: 0
+  playerRb: {fileID: 1979479478}
   usedStats: 000000000100000003000000060000000400000008000000
   baseDamage: 10
   baseCooldown: 0.3
   baseDuration: 3
   baseSpeed: 15
-  baseProjectileCount: 20
+  baseProjectileCount: 2
   baseProjectileSizeLevel: 4
   projectilePrefabs:
   - {fileID: 3140043068264800744, guid: c8d89bcbb6d3085438645054b143e33e, type: 3}
@@ -1333,17 +1334,6 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 455701329}
   m_CullTransparentMesh: 1
---- !u!114 &467799174 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 6932910660208463088, guid: 2e4a3e61f20492046a03eb54c2e6f8ae, type: 3}
-  m_PrefabInstance: {fileID: 1875735921}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1 &479815708
 GameObject:
   m_ObjectHideFlags: 0
@@ -1463,17 +1453,6 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0, y: 0}
---- !u!114 &493193445 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 6932910660208463088, guid: 2e4a3e61f20492046a03eb54c2e6f8ae, type: 3}
-  m_PrefabInstance: {fileID: 1409987052}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1 &548060761
 GameObject:
   m_ObjectHideFlags: 0
@@ -3114,17 +3093,6 @@ Transform:
   m_Children: []
   m_Father: {fileID: 1979479470}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: -632.4}
---- !u!114 &932043216 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 6932910660208463088, guid: 2e4a3e61f20492046a03eb54c2e6f8ae, type: 3}
-  m_PrefabInstance: {fileID: 107910157}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1 &936046368
 GameObject:
   m_ObjectHideFlags: 0
@@ -3158,17 +3126,25 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   slotPrefabObjects:
   - slotObj: {fileID: 1875735922}
-    background: {fileID: 467799174}
     icon: {fileID: 2054860959}
+    skillnameText: {fileID: 0}
+    statText: {fileID: 0}
+    levelText: {fileID: 0}
   - slotObj: {fileID: 107910158}
-    background: {fileID: 932043216}
     icon: {fileID: 1773033383}
+    skillnameText: {fileID: 0}
+    statText: {fileID: 0}
+    levelText: {fileID: 0}
   - slotObj: {fileID: 274167908}
-    background: {fileID: 1033536411}
     icon: {fileID: 225258783}
+    skillnameText: {fileID: 0}
+    statText: {fileID: 0}
+    levelText: {fileID: 0}
   - slotObj: {fileID: 1409987053}
-    background: {fileID: 493193445}
     icon: {fileID: 606995341}
+    skillnameText: {fileID: 0}
+    statText: {fileID: 0}
+    levelText: {fileID: 0}
   upgradePool:
   - {fileID: 11400000, guid: c0cc9c43945d7434d898c56e6b55d931, type: 2}
   - {fileID: 11400000, guid: 293398ca714e09a4184913c811a7ab4d, type: 2}
@@ -3349,17 +3325,6 @@ MonoBehaviour:
   - {fileID: 1146727613942615151, guid: dbe13d43ab80f134d83301055740344e, type: 3}
   spawnZoneCollider: {fileID: 1983897943}
   combatZoneCollider: {fileID: 788909392}
---- !u!114 &1033536411 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 6932910660208463088, guid: 2e4a3e61f20492046a03eb54c2e6f8ae, type: 3}
-  m_PrefabInstance: {fileID: 274167907}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1 &1079391491
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/02.Scripts/GHB/PlayerSkill1.cs
+++ b/Assets/02.Scripts/GHB/PlayerSkill1.cs
@@ -10,6 +10,8 @@ public class PlayerSkill1 : MonoBehaviour, ISkill
 
     public SkillType skillType;
 
+    [SerializeField] private Rigidbody2D playerRb;
+
     [Header("이 스킬이 사용하는 공용 스탯 키들")]
     [SerializeField] private List<SkillStatKey> usedStats = new List<SkillStatKey>();
 
@@ -318,13 +320,17 @@ public class PlayerSkill1 : MonoBehaviour, ISkill
         int projectileCount = Mathf.Max(1, Mathf.RoundToInt(currentProjectileCount));
         float angleStep = 360f / projectileCount;
 
+        Vector2 moveDir = playerRb.linearVelocity.normalized;
+
+        // 🔹 이동 방향의 수직 벡터 (왼쪽 방향)
+        Vector2 perpendicular = new Vector2(-moveDir.y, moveDir.x);
+        float baseAngle = Mathf.Atan2(perpendicular.y, perpendicular.x) * Mathf.Rad2Deg;
         for (int i = 0; i < projectileCount; i++)
         {
             GameObject prefabToUse = GetProjectilePrefabForLevel();
             GameObject proj = Instantiate(prefabToUse, transform.position, Quaternion.identity);
 
-            float angle = i * angleStep;
-            // 2D XY 평면 방향
+            float angle = baseAngle + (i * angleStep);
             Vector2 dir = new Vector2(Mathf.Cos(angle * Mathf.Deg2Rad), Mathf.Sin(angle * Mathf.Deg2Rad));
 
             if (proj.TryGetComponent<IProjectile>(out var projectile))
@@ -333,13 +339,13 @@ public class PlayerSkill1 : MonoBehaviour, ISkill
                 projectile.SetDuration(currentDuration);
             }
 
-            // Rigidbody2D velocity 적용
             if (proj.TryGetComponent<Rigidbody2D>(out var rb2d))
             {
                 rb2d.linearVelocity = dir.normalized * currentSpeed;
             }
         }
     }
+
 
 
 


### PR DESCRIPTION
## 💡 연관 이슈
<!-- ex) #이슈번호, #이슈번호 -->
#61 

## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->

* 기존 1번 스킬의 디폴트 상태가 월드 기준 +x, -x축으로만 발사되는 버그를 수정했습니다.
* 기존 기획대로 플레이어의 이동 방향 기준 좌우 방향이 디폴트 상태입니다.

## 스크린샷 / 동영상 (선택)


https://github.com/user-attachments/assets/f5257b3c-4d7c-4307-8751-40efae04a785


## 💬리뷰 요구사항(선택)
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요-->
<!--ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?-->

* 1번 스킬에 player의 rigidbody가 필요해서 직접 인스펙터에서 할당해주셔야 합니다. 빌드할 때 참고해주세요!
