### PR TITLE
[Refactor] 메테오 스킬 리팩토링

### DIFF
--- a/Assets/01.Scenes/KimMinSeong/#124.unity
+++ b/Assets/01.Scenes/KimMinSeong/#124.unity
@@ -181108,6 +181108,7 @@ MonoBehaviour:
   - {fileID: 6948470598453267942, guid: 0f712dcd3dc23ed4a84d66113f5d8586, type: 3}
   - {fileID: 5897547034953215948, guid: f90405bd017e75f4399db0b66120d4d1, type: 3}
   - {fileID: 186734, guid: 87ef6fb9e11601146bcd5dcb522968d4, type: 3}
+  - {fileID: 141964, guid: 1fafe872a479e244f935f1e8a8787c98, type: 3}
   - {fileID: 4246174279374542710, guid: 89139b8f26fc6914188dd4a9fd49d1c3, type: 3}
   - {fileID: 6238145512408227742, guid: f22d00e9451683840a804747912167cb, type: 3}
   - {fileID: 4529325749885727633, guid: 9078764b39bae3b4186fa63755b7b475, type: 3}
@@ -188675,11 +188676,10 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 3f63046364cbd0149a9db8d743ccfeed, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  baseDamage: 10
+  baseDamage: 5
   baseCooldown: 5
-  baseInterval: 1
-  baseBlockCount: 3
-  usedStats: 00000000010000000700000009000000
+  baseProjectileCount: 1
+  usedStats: 000000000100000004000000
   maxLevel: 8
   upgradeStep: 2
   playerTransform: {fileID: 1979479470}
@@ -188687,7 +188687,8 @@ MonoBehaviour:
   - {fileID: 186734, guid: 87ef6fb9e11601146bcd5dcb522968d4, type: 3}
   blockSpace: 15
   projectileSpace: 3
-  projectileCount: 3
+  blockCount: 3
+  blockInterval: 1
 --- !u!1 &1182626954
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/02.Scripts/GHB/Managers/PlayerSkillsManager.cs
+++ b/Assets/02.Scripts/GHB/Managers/PlayerSkillsManager.cs
@@ -14,8 +14,6 @@ public enum SkillStatKey
     EffectZoneDuration, // 장판류 스킬의 유지 시간
 
     // 밑 3개는 레거시 예정
-    Interval,       // 순차형 스킬일 때, 각 단계 사이의 시간 간격
-    BlockCount,     // 블록 단위 스킬일 때, 총 블록의 개수
     Speed          // 투사체/이동 속도 
     // 필요하면 여기에 추가
 }

--- a/Assets/02.Scripts/KimMinSeong/Skills/MeteorProjectile.cs
+++ b/Assets/02.Scripts/KimMinSeong/Skills/MeteorProjectile.cs
@@ -2,97 +2,73 @@ using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 
-public class MeteorProjectile : MonoBehaviour, IProjectile
+public class MeteorProjectile : MonoBehaviour
 {
     [Header("적 레이어 지정")]
     [SerializeField] private LayerMask targetLayer;
 
     [Header("메테오 설정")]
-    [SerializeField] private float explosionDuration = 1f; // 폭발 지속 시간
+    [SerializeField] private float explosionRadius = 2f; // 폭발 반경
+
+    [Header("파티클 관련")]
+    [SerializeField] private GameObject explosionParticle; // 폭발 파티클
 
     private float damage;
-    private Coroutine explosionCoroutine;
-    private HashSet<GameObject> damagedEnemies = new HashSet<GameObject>(); // 중복 피해 방지
-
-    [SerializeField] private GameObject muzzleParticlePrefab; // 소환 시 이펙트
-    [SerializeField] private GameObject explosionParticlePrefab; // 폭발 이펙트
-
-    public void SetDamage(float damage)
-    {
-        this.damage = damage;
-    }
-
-    public void SetDuration(float duration)
-    {
-    }
-
-    public void SetSize(float size)
-    {
-    }
 
     public void Initialize(float damage, Vector3 targetPos)
     {
-        // 데미지 설정
-        SetDamage(damage);
-
-        // 중복 피해 방지용 리스트 초기화
-        damagedEnemies.Clear();
-
-        // 폭발 이펙트 생성
-        GameObject explosionVFX = Instantiate(explosionParticlePrefab, transform.position, Quaternion.identity);
-        Destroy(explosionVFX, 2f);
-
-        // 후속 이펙트 생성
-        GameObject muzzleVFX = Instantiate(muzzleParticlePrefab, transform.position, transform.rotation);
-        Destroy(muzzleVFX, 2f);
-
-        // 폭발 코루틴 시작
-        if (explosionCoroutine != null)
-        {
-            StopCoroutine(explosionCoroutine);
-        }
-        explosionCoroutine = StartCoroutine(ExplodeCoroutine());
+        this.damage = damage;
+        Explode();
     }
 
     private void OnDisable()
     {
         damage = 0;
-        damagedEnemies.Clear();
-
-        if (explosionCoroutine != null)
-        {
-            StopCoroutine(explosionCoroutine);
-            explosionCoroutine = null;
-        }
     }
 
-    private IEnumerator ExplodeCoroutine()
+    private void Explode()
     {
-        // 폭발 이펙트가 재생되는 동안 대기
-        yield return new WaitForSeconds(explosionDuration);
+        // 폭발 파티클 생성
+        GameObject explosion = PoolManager.instance.Spawn(explosionParticle, transform.position);
+        StartCoroutine(DespawnParticle(explosion));
 
-        // 풀로 반환
+        // 폭발 범위 내의 타겟 감지
+        Collider2D[] targets = Physics2D.OverlapCircleAll(transform.position, explosionRadius, targetLayer);
+
+        foreach (var target in targets)
+        {
+            if (targetLayer.Contains(target.gameObject))
+            {
+                IDamageable damageable = target.GetComponent<IDamageable>();
+                if (damageable != null && !damageable.IsDead)
+                    damageable.TakeDamage(damage);
+            }
+        }
+
+        // 풀로 복귀
         PoolManager.instance.Despawn(this.gameObject);
     }
 
-    private void OnTriggerEnter2D(Collider2D other)
+    // 파티클 시스템이 끝날 때까지 대기한 후 풀로 복귀하는 코루틴
+    private IEnumerator DespawnParticle(GameObject particle)
     {
-        // LayerMaskHelper를 사용하여 targetLayer에 포함되는지 확인
-        if (!targetLayer.Contains(other.gameObject.layer))
-            return;
+        ParticleSystem ps = particle.GetComponent<ParticleSystem>();
 
-        // 이미 피해를 입힌 적이라면 스킵
-        if (damagedEnemies.Contains(other.gameObject))
-            return;
+        // ParticleSystem이 재생 중일 때까지 대기
+        while (ps != null && ps.isPlaying)
+            yield return null;
 
-        // IDamageable 인터페이스로 데미지 처리
-        IDamageable damageable = other.GetComponent<IDamageable>();
-        if (damageable != null && !damageable.IsDead)
-        {
-            damageable.TakeDamage(damage);
-            damagedEnemies.Add(other.gameObject);
+        // 모든 파티클이 완전히 사라질 때까지 추가적으로 대기
+        yield return new WaitForSeconds(ps.main.startLifetime.constantMax);
 
-            Debug.Log($"메테오 폭발! 대상: {other.name}, 데미지: {damage}");
-        }
+        // 풀로 복귀
+        PoolManager.instance.Despawn(particle);
+    }
+
+    // 디버그용 기즈모
+    private void OnDrawGizmosSelected()
+    {
+        Gizmos.color = Color.red;
+        Gizmos.DrawWireSphere(transform.position, explosionRadius);
     }
 }

--- a/Assets/02.Scripts/Skills/Skill8/PlayerSkill8.cs
+++ b/Assets/02.Scripts/Skills/Skill8/PlayerSkill8.cs
@@ -9,8 +9,8 @@ public class PlayerSkill8 : MonoBehaviour, ISkill
     [Header("스킬이 사용하는 기본값")]
     [SerializeField] private float baseDamage = 10f;
     [SerializeField] private float baseCooldown = 5f;
-    [SerializeField] private float baseInterval = 1f;
-    [SerializeField] private int baseBlockCount = 3;
+    [SerializeField] private int baseProjectileCount = 3;
+
 
     [Header("스킬이 사용하는 공용 스탯 키들")]
     [SerializeField] private List<SkillStatKey> usedStats = new List<SkillStatKey>();
@@ -36,8 +36,9 @@ public class PlayerSkill8 : MonoBehaviour, ISkill
     [SerializeField] private int blockSpace = 3;    // 블록 사이의 간격
     [SerializeField] private int projectileSpace = 3;    // 블록 내부의 투사체 사이의 간격
 
-    [Header("블록 안에 투사체 개수")]
-    [SerializeField] private int projectileCount = 3;
+    [Header("블록 관련")]
+    [SerializeField] private int blockCount = 3;
+    [SerializeField] private float blockInterval = 1f;
 
     private Coroutine passiveRoutine;
     private Coroutine meteorRoutine;
@@ -51,18 +52,16 @@ public class PlayerSkill8 : MonoBehaviour, ISkill
     }
     public float CurrentDamage => statValues[SkillStatKey.Damage];
     public float CurrentCooldown => statValues[SkillStatKey.Cooldown];
-    public float CurrentInterval => statValues[SkillStatKey.Interval];
-    public int CurrentBlockCount => (int)statValues[SkillStatKey.BlockCount];
-
-
+    public float CurrentProjectileCount => (int)statValues[SkillStatKey.ProjectileCount];
+    public int CurrentBlockCount => blockCount;
+    public float CurrentInterval => blockInterval;
 
     private void Awake()
     {
         // 사용하는 스탯에 해당하는 값들을 초기화
         statValues[SkillStatKey.Damage] = baseDamage;
         statValues[SkillStatKey.Cooldown] = baseCooldown;
-        statValues[SkillStatKey.Interval] = baseInterval;
-        statValues[SkillStatKey.BlockCount] = baseBlockCount;
+        statValues[SkillStatKey.ProjectileCount] = baseProjectileCount;
     }
 
     private void OnEnable()
@@ -152,10 +151,10 @@ public class PlayerSkill8 : MonoBehaviour, ISkill
 
     private void SpawnMeteors(Vector3 blockCenter, Vector3 right, GameObject meteor)
     {
-        for (int i = 0; i < projectileCount; ++i)
+        for (int i = 0; i < CurrentProjectileCount; ++i)
         {
             // 중앙을 기준으로 좌우 대칭적으로 투사체를 배치
-            float offset = (i - (projectileCount - 1) / 2f) * projectileSpace;
+            float offset = (i - (CurrentProjectileCount - 1) / 2f) * projectileSpace;
 
             // 생성 위치 계산
             Vector3 spawnPosition = blockCenter + right * offset;
@@ -203,7 +202,7 @@ public class PlayerSkill8 : MonoBehaviour, ISkill
 
         // 3. 스탯에 해당하는 값을 갱신
         // 쿨타임, 메테오 낙하 시간 간격 업그레이드는 감소하도록 설정
-        if (data.statKey == SkillStatKey.Cooldown || data.statKey == SkillStatKey.Interval)
+        if (data.statKey == SkillStatKey.Cooldown)
             statValues[data.statKey] *= 1f - data.upgradeRatio;
         else
             statValues[data.statKey] *= 1f + data.upgradeRatio;
@@ -221,8 +220,7 @@ public class PlayerSkill8 : MonoBehaviour, ISkill
         // 사용하는 스탯의 값들을 초기화
         statValues[SkillStatKey.Damage] = baseDamage;
         statValues[SkillStatKey.Cooldown] = baseCooldown;
-        statValues[SkillStatKey.Interval] = baseInterval;
-        statValues[SkillStatKey.BlockCount] = baseBlockCount;
+        statValues[SkillStatKey.ProjectileCount] = baseProjectileCount;
 
         currentLevel = 0;
 


### PR DESCRIPTION
# 💡 연관 이슈
<!-- ex) #이슈번호, #이슈번호 -->
#126 

# 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->
## 1. 메테오 스킬 리팩토링
  - 메테오 스킬을 리팩토링하였습니다. 내용은 다음과 같습니다.
    1. `Block Count`, `Interval` 변수를 제거하고, 메테오 스킬은 `ProjectileCount`, `Damage`, `Cooldown` 을 사용하도록 변경하였습니다.
    2. `Circle Collider` 를 제거하고 `Physics.OverlapsCircle` 를 사용하여 데미지 판정을 처리하였습니다.
